### PR TITLE
Fix DynamicOptimizer thread-safety and double-evaluation bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.thingsboard</groupId>
     <artifactId>tbel</artifactId>
     <packaging>jar</packaging>
-    <version>1.2.8</version>
+    <version>1.2.9</version>
 
     <name>tbel</name>
     <url>https://thingsboard.io/</url>

--- a/src/main/java/org/mvel2/optimizers/OptimizerFactory.java
+++ b/src/main/java/org/mvel2/optimizers/OptimizerFactory.java
@@ -32,7 +32,7 @@ public class OptimizerFactory {
   public static String SAFE_REFLECTIVE = "reflective";
 
   private static final Logger LOG = Logger.getLogger(OptimizerFactory.class.getName());
-  private static String defaultOptimizer;
+  private static volatile String defaultOptimizer;
   private static final Map<String, AccessorOptimizer> accessorCompilers = new HashMap<String, AccessorOptimizer>();
 
   private static ThreadLocal<Class<? extends AccessorOptimizer>> threadOptimizer

--- a/src/main/java/org/mvel2/optimizers/dynamic/DynamicCollectionAccessor.java
+++ b/src/main/java/org/mvel2/optimizers/dynamic/DynamicCollectionAccessor.java
@@ -68,7 +68,9 @@ public class DynamicCollectionAccessor implements DynamicAccessor {
             return optimize(pCtx, ctx, elCtx, variableFactory);
           }
           catch (OptimizationNotSupported ex) {
-            deoptimize();
+            // Optimization failed permanently for this accessor; keep opt=true
+            // so we never retry, and fall through to use _safeAccessor
+            _accessor = _safeAccessor;
           }
         }
         else {

--- a/src/main/java/org/mvel2/optimizers/dynamic/DynamicCollectionAccessor.java
+++ b/src/main/java/org/mvel2/optimizers/dynamic/DynamicCollectionAccessor.java
@@ -21,6 +21,7 @@ package org.mvel2.optimizers.dynamic;
 import org.mvel2.ParserContext;
 import org.mvel2.compiler.Accessor;
 import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.optimizers.OptimizationNotSupported;
 import org.mvel2.optimizers.OptimizerFactory;
 
 import static java.lang.System.currentTimeMillis;
@@ -37,12 +38,12 @@ public class DynamicCollectionAccessor implements DynamicAccessor {
   private long stamp;
   private int type;
 
-  private int runcount;
+  private volatile int runcount;
 
-  private boolean opt = false;
+  private volatile boolean opt = false;
 
   private Accessor _safeAccessor;
-  private Accessor _accessor;
+  private volatile Accessor _accessor;
 
   public DynamicCollectionAccessor(ParserContext pCtx, Object rootObject, Class colType, char[] property, int start, int offset, int type, Accessor _accessor) {
     this.pCtx = pCtx;
@@ -63,8 +64,12 @@ public class DynamicCollectionAccessor implements DynamicAccessor {
       if (++runcount > DynamicOptimizer.tenuringThreshold) {
         if ((currentTimeMillis() - stamp) < DynamicOptimizer.timeSpan) {
           opt = true;
-
-          return optimize(pCtx, ctx, elCtx, variableFactory);
+          try {
+            return optimize(pCtx, ctx, elCtx, variableFactory);
+          }
+          catch (OptimizationNotSupported ex) {
+            deoptimize();
+          }
         }
         else {
           runcount = 0;

--- a/src/main/java/org/mvel2/optimizers/dynamic/DynamicGetAccessor.java
+++ b/src/main/java/org/mvel2/optimizers/dynamic/DynamicGetAccessor.java
@@ -65,8 +65,9 @@ public class DynamicGetAccessor implements DynamicAccessor {
             return optimize(ctx, elCtx, variableFactory);
           }
           catch(OptimizationNotSupported ex){
-        	  // If optimization fails, reset to safe reflective accessor to prevent future reattempts
-        	  deoptimize();
+        	  // Optimization failed permanently for this accessor; keep opt=true
+        	  // so we never retry, and fall through to use _safeAccessor
+        	  _accessor = _safeAccessor;
           }
         }
         else {

--- a/src/main/java/org/mvel2/optimizers/dynamic/DynamicGetAccessor.java
+++ b/src/main/java/org/mvel2/optimizers/dynamic/DynamicGetAccessor.java
@@ -35,14 +35,14 @@ public class DynamicGetAccessor implements DynamicAccessor {
   private long stamp;
   private int type;
 
-  private int runcount;
+  private volatile int runcount;
 
-  private boolean opt = false;
+  private volatile boolean opt = false;
 
   private ParserContext pCtx;
 
   private Accessor _safeAccessor;
-  private Accessor _accessor;
+  private volatile Accessor _accessor;
 
   public DynamicGetAccessor(ParserContext pCtx, char[] expr, int start, int offset, int type, Accessor _accessor) {
     this._safeAccessor = this._accessor = _accessor;
@@ -65,7 +65,8 @@ public class DynamicGetAccessor implements DynamicAccessor {
             return optimize(ctx, elCtx, variableFactory);
           }
           catch(OptimizationNotSupported ex){
-        	  // If optimization fails then, rather than fail evaluation, fallback to use safe reflective accessor
+        	  // If optimization fails, reset to safe reflective accessor to prevent future reattempts
+        	  deoptimize();
           }
         }
         else {

--- a/src/main/java/org/mvel2/optimizers/dynamic/DynamicSetAccessor.java
+++ b/src/main/java/org/mvel2/optimizers/dynamic/DynamicSetAccessor.java
@@ -31,13 +31,13 @@ public class DynamicSetAccessor implements DynamicAccessor {
   private int start;
   private int offset;
 
-  private boolean opt = false;
-  private int runcount = 0;
+  private volatile boolean opt = false;
+  private volatile int runcount = 0;
   private long stamp;
 
   private ParserContext context;
   private final Accessor _safeAccessor;
-  private Accessor _accessor;
+  private volatile Accessor _accessor;
   private String description;
 
   public DynamicSetAccessor(ParserContext context, char[] property, int start, int offset, Accessor _accessor) {

--- a/src/main/java/org/mvel2/optimizers/dynamic/DynamicSetAccessor.java
+++ b/src/main/java/org/mvel2/optimizers/dynamic/DynamicSetAccessor.java
@@ -22,6 +22,7 @@ import org.mvel2.ParserContext;
 import org.mvel2.compiler.Accessor;
 import org.mvel2.integration.VariableResolverFactory;
 import org.mvel2.optimizers.AccessorOptimizer;
+import org.mvel2.optimizers.OptimizationNotSupported;
 import org.mvel2.optimizers.OptimizerFactory;
 
 import static java.lang.System.currentTimeMillis;
@@ -57,7 +58,14 @@ public class DynamicSetAccessor implements DynamicAccessor {
       if (++runcount > DynamicOptimizer.tenuringThreshold) {
         if ((currentTimeMillis() - stamp) < DynamicOptimizer.timeSpan) {
           opt = true;
-          return optimize(ctx, elCtx, variableFactory, value);
+          try {
+            return optimize(ctx, elCtx, variableFactory, value);
+          }
+          catch (OptimizationNotSupported ex) {
+            // Optimization failed permanently for this accessor; keep opt=true
+            // so we never retry, and fall through to use _safeAccessor
+            _accessor = _safeAccessor;
+          }
         }
         else {
           runcount = 0;

--- a/src/main/java/org/mvel2/optimizers/impl/refl/nodes/MethodAccessor.java
+++ b/src/main/java/org/mvel2/optimizers/impl/refl/nodes/MethodAccessor.java
@@ -26,6 +26,7 @@ import org.mvel2.integration.VariableResolverFactory;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 
+import static org.mvel2.DataConversion.convert;
 import static org.mvel2.util.ParseTools.getBestCandidate;
 import static org.mvel2.util.ParseTools.getWidenedTarget;
 
@@ -137,6 +138,36 @@ public class MethodAccessor extends InvokableAccessor {
             "actual target: " + ctx.getClass().getName() + "::" + method.getName() + "; coercionNeeded=" + (coercionNeeded ? "yes" : "no") + ")");
       }
     }
+  }
+
+  @Override
+  protected Object[] executeAndCoerce(Class[] target, Object elCtx, VariableResolverFactory vars, boolean isVarargs) {
+    if (executionContextParamIndex < 0) {
+      return super.executeAndCoerce(target, elCtx, vars, isVarargs);
+    }
+    Object[] values = new Object[length];
+    int paramIndex = 0;
+    for (int i = 0; i < length && !(isVarargs && i >= length - 1); i++) {
+      if (i == executionContextParamIndex) {
+        values[i] = elCtx instanceof ExecutionContext ? elCtx : null;
+      } else {
+        values[i] = convert(parms[paramIndex++].getValue(elCtx, vars), target[i]);
+      }
+    }
+    if (isVarargs) {
+      Class<?> componentType = target[length - 1].getComponentType();
+      Object vararg;
+      if (parms == null) {
+        vararg = java.lang.reflect.Array.newInstance(componentType, 0);
+      } else {
+        vararg = java.lang.reflect.Array.newInstance(componentType, parms.length - paramIndex);
+        for (int i = 0; i < parms.length - paramIndex; i++) {
+          java.lang.reflect.Array.set(vararg, i, convert(parms[paramIndex + i].getValue(elCtx, vars), componentType));
+        }
+      }
+      values[length - 1] = vararg;
+    }
+    return values;
   }
 
   private Object[] executeAll(Object ctx, VariableResolverFactory vars, Method m) {

--- a/src/test/java/org/mvel2/tests/core/DynamicOptimizerPostIncrementTest.java
+++ b/src/test/java/org/mvel2/tests/core/DynamicOptimizerPostIncrementTest.java
@@ -1,0 +1,124 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.tests.core;
+
+import junit.framework.TestCase;
+import org.mvel2.MVEL;
+import org.mvel2.optimizers.OptimizerFactory;
+import org.mvel2.optimizers.dynamic.DynamicOptimizer;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Test that post-increment expressions inside array/collection access
+ * work correctly under the DynamicOptimizer (ASM JIT tenuring).
+ *
+ * Regression test for double-evaluation bug where i++ in input[i++]
+ * could be evaluated twice when ASM optimization triggers or fails.
+ */
+public class DynamicOptimizerPostIncrementTest extends TestCase {
+
+    /**
+     * Verify that input[i++] in a loop produces correct results
+     * when executed enough times to trigger DynamicOptimizer tenuring.
+     * Before the fix, after the tenuring threshold was reached, the ASM
+     * optimizer could double-evaluate i++, skipping bytes.
+     */
+    public void testPostIncrementInArrayAccessWithDynamicOptimizer() {
+        int oldThreshold = DynamicOptimizer.tenuringThreshold;
+        long oldTimeSpan = DynamicOptimizer.timeSpan;
+
+        try {
+            // Force DynamicOptimizer with low tenuring threshold
+            DynamicOptimizer.tenuringThreshold = 1;
+            DynamicOptimizer.timeSpan = 1000 * 60 * 60L; // 1 hour
+            OptimizerFactory.setDefaultOptimizer(OptimizerFactory.DYNAMIC);
+
+            String script =
+                "var input = [0x02, 0x75, 45, 0x01, 0x75, 55, 0x03, 0x76, 75];\n" +
+                "var result = [];\n" +
+                "for (var i = 0; i < input.size;) {\n" +
+                "    var channel_id = input[i++];\n" +
+                "    var channel_type = input[i++];\n" +
+                "    result.add(channel_id);\n" +
+                "    result.add(channel_type);\n" +
+                "    i += 1;\n" +
+                "}\n" +
+                "return result;";
+
+            Serializable compiled = MVEL.compileExpression(script);
+
+            // Execute many times to trigger tenuring (threshold is 1,
+            // so optimization triggers on the 2nd call)
+            for (int i = 0; i < 10; i++) {
+                Object result = MVEL.executeExpression(compiled, new HashMap<>());
+                assertNotNull("Run " + i + ": result should not be null", result);
+                // Expected: [2, 117, 1, 117, 3, 118]
+                // channel pairs: (0x02,0x75), (0x01,0x75), (0x03,0x76)
+                assertEquals("Run " + i + ": wrong result",
+                    "[2, 117, 1, 117, 3, 118]", result.toString());
+            }
+        } finally {
+            DynamicOptimizer.tenuringThreshold = oldThreshold;
+            DynamicOptimizer.timeSpan = oldTimeSpan;
+            OptimizerFactory.setDefaultOptimizer(OptimizerFactory.SAFE_REFLECTIVE);
+        }
+    }
+
+    /**
+     * Test that volatile defaultOptimizer ensures cross-thread visibility.
+     * One thread sets SAFE_REFLECTIVE, worker threads must see it.
+     */
+    public void testOptimizerVisibilityAcrossThreads() throws Exception {
+        OptimizerFactory.setDefaultOptimizer(OptimizerFactory.SAFE_REFLECTIVE);
+
+        final int threadCount = 20;
+        final int iterations = 100;
+        final AtomicInteger errors = new AtomicInteger(0);
+        final CountDownLatch start = new CountDownLatch(1);
+        final CountDownLatch done = new CountDownLatch(threadCount);
+
+        for (int t = 0; t < threadCount; t++) {
+            new Thread(() -> {
+                try {
+                    start.await();
+                    for (int i = 0; i < iterations; i++) {
+                        var optimizer = OptimizerFactory.getDefaultAccessorCompiler();
+                        if (optimizer instanceof DynamicOptimizer) {
+                            errors.incrementAndGet();
+                        }
+                    }
+                } catch (Exception e) {
+                    errors.incrementAndGet();
+                } finally {
+                    done.countDown();
+                }
+            }).start();
+        }
+
+        start.countDown();
+        done.await(10, TimeUnit.SECONDS);
+        assertEquals("Some threads saw DynamicOptimizer instead of SAFE_REFLECTIVE",
+            0, errors.get());
+    }
+}


### PR DESCRIPTION
## Summary

### DynamicOptimizer thread-safety and double-evaluation fix

- Make `OptimizerFactory.defaultOptimizer` volatile to ensure cross-thread visibility when ThingsBoard sets `SAFE_REFLECTIVE` during init — without this, worker threads can read the stale `DYNAMIC` value due to Java Memory Model visibility rules
- Call `_accessor = _safeAccessor` on `OptimizationNotSupported` in `DynamicGetAccessor` instead of silently falling through, which caused `i++` to be evaluated twice (once during failed ASM compilation, once in the fallback `_accessor.getValue()`)
- Add missing `OptimizationNotSupported` catch in `DynamicCollectionAccessor.getValue()` and `DynamicSetAccessor.setValue()` — both had the same unhandled exception gap
- All three catch blocks keep `opt=true` to prevent repeated optimization reattempts for expressions that consistently fail ASM compilation
- Make thread-shared fields (`runcount`, `opt`, `_accessor`) volatile in all `Dynamic*Accessor` classes, since compiled expressions and their accessor trees are cached and shared across threads
- Add regression test `DynamicOptimizerPostIncrementTest` for post-increment in array access under DynamicOptimizer

### MethodAccessor ExecutionContext injection fix

- Override `executeAndCoerce` in `MethodAccessor` to handle `executionContextParamIndex`, mirroring how `executeAll` already does it
- `InvokableAccessor.executeAndCoerce()` (used when `coercionNeeded=true`) had no knowledge of `executionContextParamIndex`, causing it to try to convert a user argument to `ExecutionContext` — which fails with NPE since there is no `ConversionHandler` for `ExecutionContext`
- This manifests when a method with an `ExecutionContext` parameter receives an argument needing type coercion (e.g., `ExecutionArrayList` passed where `byte[]` is expected): the first execution uses the interpretive path and succeeds, but subsequent executions use the cached `MethodAccessor`, hit `IllegalArgumentException`, set `coercionNeeded=true`, and then NPE in `executeAndCoerce`

### Version bump

- Bump version to 1.2.9

## Test plan

- [x] Run `mvn test -Dtest=DynamicOptimizerPostIncrementTest` — both test methods should pass
- [x] Run full TBEL test suite: `mvn test`
- [x] Update ThingsBoard CE `tbel.version` to `1.2.9` and run `TbelInvokeDocsIoTest#parseBytes_Test` (repeated) — all runs should pass consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)