### PR TITLE
Improved TBEL script sandbox security against file and network abuse

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.thingsboard</groupId>
     <artifactId>tbel</artifactId>
     <packaging>jar</packaging>
-    <version>1.2.9</version>
+    <version>1.2.10</version>
 
     <name>tbel</name>
     <url>https://thingsboard.io/</url>

--- a/src/main/java/org/mvel2/SandboxedClassLoader.java
+++ b/src/main/java/org/mvel2/SandboxedClassLoader.java
@@ -37,6 +37,11 @@ public class SandboxedClassLoader extends URLClassLoader {
     public SandboxedClassLoader() {
         super(new URL[0], Thread.currentThread().getContextClassLoader());
         forbiddenPackages.add("java.util.concurrent");
+        forbiddenPackages.add("java.util.logging");
+        forbiddenPackages.add("java.util.zip");
+        forbiddenPackages.add("java.util.jar");
+        forbiddenPackages.add("java.util.prefs");
+        forbiddenPackages.add("java.util.spi");
         allowedPackages.add("java.util");
         AbstractParser.CLASS_LITERALS
                 .entrySet().stream().filter(entry -> !forbiddenClassLiterals.contains(entry.getKey()))

--- a/src/test/java/org/mvel2/tests/core/TbExpressionsTest.java
+++ b/src/test/java/org/mvel2/tests/core/TbExpressionsTest.java
@@ -548,6 +548,63 @@ public class TbExpressionsTest extends TestCase {
         assertEquals(5, res);
     }
 
+    public void testForbiddenUtilSubpackageAccess() {
+        // SSRF via SocketHandler
+        try {
+            executeScript("new java.util.logging.SocketHandler(\"127.0.0.1\", 9999)");
+            fail("Should throw CompileException for java.util.logging.SocketHandler");
+        } catch (CompileException e) {
+            assertTrue(e.getMessage().contains("could not resolve class: java.util.logging.SocketHandler"));
+        }
+
+        // File write via FileHandler
+        try {
+            executeScript("new java.util.logging.FileHandler(\"/tmp/test.log\")");
+            fail("Should throw CompileException for java.util.logging.FileHandler");
+        } catch (CompileException e) {
+            assertTrue(e.getMessage().contains("could not resolve class: java.util.logging.FileHandler"));
+        }
+
+        // File read via ZipFile
+        try {
+            executeScript("new java.util.zip.ZipFile(\"/tmp/test.zip\")");
+            fail("Should throw CompileException for java.util.zip.ZipFile");
+        } catch (CompileException e) {
+            assertTrue(e.getMessage().contains("could not resolve class: java.util.zip.ZipFile"));
+        }
+
+        // File read via JarFile
+        try {
+            executeScript("new java.util.jar.JarFile(\"/tmp/test.jar\")");
+            fail("Should throw CompileException for java.util.jar.JarFile");
+        } catch (CompileException e) {
+            assertTrue(e.getMessage().contains("could not resolve class: java.util.jar.JarFile"));
+        }
+
+        // System prefs read/write via Preferences
+        try {
+            executeScript("java.util.prefs.Preferences.userRoot()");
+            fail("Should throw CompileException for java.util.prefs.Preferences");
+        } catch (CompileException e) {
+            assertTrue(e.getMessage().contains("unresolvable property or identifier: java"));
+        }
+
+        // Service provider loading via spi
+        try {
+            executeScript("new java.util.spi.LocaleServiceProvider()");
+            fail("Should throw CompileException for java.util.spi.LocaleServiceProvider");
+        } catch (CompileException e) {
+            assertTrue(e.getMessage().contains("could not resolve class: java.util.spi.LocaleServiceProvider"));
+        }
+
+        // Verify legitimate java.util classes still work
+        Object res = executeScript("m = {1, 2, 3}; m.size()");
+        assertEquals(3, res);
+
+        res = executeScript("m = {key: \"val\"}; m.get(\"key\")");
+        assertEquals("val", res);
+    }
+
     public void testForbidImport() {
         try {
             executeScript("import java.util.HashMap; m = new HashMap(); m.put('t', 10); m");


### PR DESCRIPTION
## Summary
- Add `java.util.logging`, `java.util.zip`, `java.util.jar`, `java.util.prefs`, `java.util.spi` to `forbiddenPackages` in `SandboxedClassLoader`
- Add tests verifying sandbox blocks `SocketHandler`, `FileHandler`, `ZipFile`, `JarFile`, `Preferences`, `LocaleServiceProvider`
- Add regression tests verifying legitimate `java.util` collections still work

## Problem
The `allowedPackages` entry `"java.util"` uses prefix matching (`startsWith`), which inadvertently permits all subpackages. This allows a Tenant Admin to:
1. **SSRF** via `java.util.logging.SocketHandler` — scan internal ports
2. **File read** via `java.util.zip.ZipFile` / `java.util.jar.JarFile` — read arbitrary files including DB credentials
3. **File write** via `java.util.logging.FileHandler` — write files to arbitrary paths

## Fix
Add the dangerous subpackages to `forbiddenPackages`, following the existing pattern used for `java.util.concurrent`.