### PR TITLE
Fixed arbitrary file write in TBEL script sandbox

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.thingsboard</groupId>
     <artifactId>tbel</artifactId>
     <packaging>jar</packaging>
-    <version>1.2.10</version>
+    <version>1.2.11</version>
 
     <name>tbel</name>
     <url>https://thingsboard.io/</url>

--- a/src/main/java/org/mvel2/SandboxedClassLoader.java
+++ b/src/main/java/org/mvel2/SandboxedClassLoader.java
@@ -15,6 +15,8 @@ public class SandboxedClassLoader extends URLClassLoader {
             Set.of("System",  "Runtime", "Class", "ClassLoader", "Thread", "Compiler", "ThreadLocal", "SecurityManager", "Array", "StringBuffer", "StringBuilder", "Module");
     protected static final Set<String> forbiddenMethodsClasses = forbiddenClassLiterals;
 
+    protected static final Set<String> forbiddenClasses = Set.of("java.util.Formatter");
+
     protected static final Set<Method> forbiddenMethods = Set.of(
             getMethod(Object.class, "getClass"),
             getMethod(Class.class, "getClassLoader")
@@ -73,6 +75,9 @@ public class SandboxedClassLoader extends URLClassLoader {
     }
 
     private boolean classNameAllowed(String name) {
+        if (forbiddenClasses.contains(name)) {
+            return false;
+        }
         if (allowedClasses.contains(name)) {
             return true;
         }

--- a/src/test/java/org/mvel2/tests/core/TbExpressionsTest.java
+++ b/src/test/java/org/mvel2/tests/core/TbExpressionsTest.java
@@ -605,6 +605,18 @@ public class TbExpressionsTest extends TestCase {
         assertEquals("val", res);
     }
 
+    public void testForbiddenFormatterFileWrite() {
+        String path = "/tmp/tbel_formatter_test.txt";
+        try {
+            executeScript("new java.util.Formatter(\"" + path + "\")");
+            fail("Should throw CompileException for java.util.Formatter");
+        } catch (CompileException e) {
+            assertTrue(e.getMessage().contains("could not resolve class: java.util.Formatter"));
+        } finally {
+            new java.io.File(path).delete();
+        }
+    }
+
     public void testForbidImport() {
         try {
             executeScript("import java.util.HashMap; m = new HashMap(); m.put('t', 10); m");


### PR DESCRIPTION
## Summary
- Block `java.util.Formatter` in `SandboxedClassLoader` via a new `forbiddenClasses` exact-match denylist
- Add a test verifying the sandbox blocks `java.util.Formatter`
- Bump version 1.2.10 → 1.2.11

## Problem
The `allowedPackages` entry `"java.util"` uses `startsWith` prefix matching, which permits every top-level `java.util` class. `java.util.Formatter` has a `Formatter(String fileName)` constructor that opens the named file for writing, so a Tenant Admin can write arbitrary content to an arbitrary path from a TBEL script:

```
new java.util.Formatter("/path/of/attackers/choosing").format("...", 1337).close()
```

## Fix
Add `java.util.Formatter` to a `forbiddenClasses` set that is checked first in `classNameAllowed`, so the denylist wins over the `java.util` package allow and the class can no longer be loaded. This follows the existing forbidden-list pattern; the escape now fails at class resolution with `could not resolve class: java.util.Formatter`, identical to the blocked subpackages.

## Test plan
Automated test in `TbExpressionsTest`:
- `testForbiddenFormatterFileWrite` — verifies `new java.util.Formatter(...)` is blocked and no file is created.

All 98 tests in `TbExpressionsTest` pass (legitimate `java.util` collections are unaffected).
